### PR TITLE
Add Next.js frontend and Django backend for Nxentra auth onboarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Node
+frontend/node_modules
+frontend/.next
+frontend/.turbo
+
+# Python
+backend/.venv
+backend/__pycache__/
+backend/**/__pycache__/
+*.pyc
+
+# Env files
+frontend/.env
+backend/.env
+
+# OS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,58 @@
-# nxentra-register
-nxentra register login logout system
+# Nxentra Register/Login Stack
+
+This repository bootstraps a modern authentication and onboarding stack for the Nxentra Smart ERP platform. It provides a Next.js front end (deployable on Vercel) and a Django REST + PostgreSQL back end (deployable on DigitalOcean) that work together to onboard tenants and manage authentication.
+
+## Architecture
+
+- **frontend/** – Next.js 14 + TailwindCSS application that provides Register, Login, Profile flows and animated onboarding feedback.
+- **backend/** – Django REST Framework API with JWT authentication that persists users and company workspace preferences to PostgreSQL.
+
+## Features
+
+### Registration flow
+
+1. Collects core identity details (email, full name, password).
+2. Captures tenant configuration: company identifier (max 10 characters, no spaces), currency, language (Arabic/English), number of accounting periods, current period, thousand separator, decimal precision/separator, and date format.
+3. Displays an animated loader while the workspace is being prepared and then redirects the user to the profile view with the saved settings.
+
+### Authentication
+
+- JWT based login/logout using `djangorestframework-simplejwt` with refresh token rotation and blacklisting.
+- Profile endpoint returns both user details and ERP configuration so the front end can render the workspace summary.
+
+## Local development
+
+### Back end
+
+```bash
+cd backend
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env
+python manage.py migrate
+python manage.py runserver 0.0.0.0:8000
+```
+
+The API will be available at `http://localhost:8000/api/`.
+
+### Front end
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+The Next.js application will be available at `http://localhost:3000` and expects `NEXT_PUBLIC_API_URL` to point at the deployed Django API (defaults to `http://localhost:8000/api`).
+
+## Deployment notes
+
+- Deploy the `frontend` directory to Vercel. Configure the environment variable `NEXT_PUBLIC_API_URL` with the public DigitalOcean API URL.
+- Deploy the `backend` directory to a DigitalOcean App Platform or Droplet. Provide the environment variables listed in `backend/.env.example` and make sure PostgreSQL is reachable (DigitalOcean Managed Database recommended).
+- Ensure HTTPS origins are whitelisted in both `CORS_ALLOWED_ORIGINS` and `CSRF_TRUSTED_ORIGINS`.
+
+## Next steps
+
+- Harden password policies and add multi-factor authentication.
+- Implement tenant-aware schema provisioning if each company requires an isolated database.
+- Add automated tests for serializers and UI components.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,10 @@
+DJANGO_SECRET_KEY=change-me
+DJANGO_DEBUG=True
+DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1
+CORS_ALLOWED_ORIGINS=http://localhost:3000,https://your-vercel-domain.vercel.app
+CSRF_TRUSTED_ORIGINS=http://localhost:3000,https://your-vercel-domain.vercel.app
+POSTGRES_DB=nxentra
+POSTGRES_USER=nxentra
+POSTGRES_PASSWORD=super-secure-password
+POSTGRES_HOST=localhost
+POSTGRES_PORT=5432

--- a/backend/accounts/admin.py
+++ b/backend/accounts/admin.py
@@ -1,0 +1,25 @@
+from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin as DjangoUserAdmin
+
+from .models import Company, User
+
+
+@admin.register(User)
+class UserAdmin(DjangoUserAdmin):
+    fieldsets = (
+        (None, {"fields": ("email", "password", "name")}),
+        ("Permissions", {"fields": ("is_active", "is_staff", "is_superuser", "groups", "user_permissions")}),
+        ("Important dates", {"fields": ("last_login", "date_joined")}),
+    )
+    add_fieldsets = (
+        (None, {"classes": ("wide",), "fields": ("email", "name", "password1", "password2")}),
+    )
+    list_display = ("email", "name", "is_staff")
+    search_fields = ("email", "name")
+    ordering = ("email",)
+
+
+@admin.register(Company)
+class CompanyAdmin(admin.ModelAdmin):
+    list_display = ("name", "currency", "language", "owner")
+    search_fields = ("name", "owner__email")

--- a/backend/accounts/apps.py
+++ b/backend/accounts/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class AccountsConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "accounts"

--- a/backend/accounts/migrations/0001_initial.py
+++ b/backend/accounts/migrations/0001_initial.py
@@ -1,0 +1,55 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+import django.contrib.auth.validators
+import django.utils.timezone
+
+
+class Migration(migrations.Migration):
+    initial = True
+
+    dependencies = [
+        ("auth", "0012_alter_user_first_name_max_length"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="User",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("password", models.CharField(max_length=128, verbose_name="password")),
+                ("last_login", models.DateTimeField(blank=True, null=True, verbose_name="last login")),
+                ("is_superuser", models.BooleanField(default=False, help_text="Designates that this user has all permissions without explicitly assigning them.", verbose_name="superuser status")),
+                ("first_name", models.CharField(blank=True, max_length=150, verbose_name="first name")),
+                ("last_name", models.CharField(blank=True, max_length=150, verbose_name="last name")),
+                ("is_staff", models.BooleanField(default=False, help_text="Designates whether the user can log into this admin site.", verbose_name="staff status")),
+                ("is_active", models.BooleanField(default=True, help_text="Designates whether this user should be treated as active.", verbose_name="active")),
+                ("date_joined", models.DateTimeField(default=django.utils.timezone.now, verbose_name="date joined")),
+                ("email", models.EmailField(max_length=254, unique=True, verbose_name="email address")),
+                ("name", models.CharField(max_length=150)),
+                ("groups", models.ManyToManyField(blank=True, related_name="user_set", related_query_name="user", to="auth.group", verbose_name="groups")),
+                ("user_permissions", models.ManyToManyField(blank=True, related_name="user_set", related_query_name="user", to="auth.permission", verbose_name="user permissions")),
+            ],
+            options={
+                "verbose_name": "user",
+                "verbose_name_plural": "users",
+            },
+        ),
+        migrations.CreateModel(
+            name="Company",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("name", models.CharField(max_length=10, unique=True)),
+                ("currency", models.CharField(max_length=3)),
+                ("language", models.CharField(choices=[("en", "English"), ("ar", "Arabic")], max_length=5)),
+                ("periods", models.PositiveSmallIntegerField(default=12)),
+                ("current_period", models.PositiveSmallIntegerField(default=1)),
+                ("thousand_separator", models.CharField(blank=True, max_length=1)),
+                ("decimal_places", models.PositiveSmallIntegerField(default=2)),
+                ("decimal_separator", models.CharField(default=".", max_length=1)),
+                ("date_format", models.CharField(default="dd/mm/yyyy", max_length=20)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("owner", models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, related_name="company", to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+    ]

--- a/backend/accounts/models.py
+++ b/backend/accounts/models.py
@@ -1,0 +1,68 @@
+from django.conf import settings
+from django.contrib.auth.models import AbstractUser, BaseUserManager
+from django.db import models
+from django.utils.translation import gettext_lazy as _
+
+
+class UserManager(BaseUserManager):
+    use_in_migrations = True
+
+    def _create_user(self, email, password, **extra_fields):
+        if not email:
+            raise ValueError("The given email must be set")
+        email = self.normalize_email(email)
+        user = self.model(email=email, **extra_fields)
+        user.set_password(password)
+        user.save(using=self._db)
+        return user
+
+    def create_user(self, email, password=None, **extra_fields):
+        extra_fields.setdefault("is_staff", False)
+        extra_fields.setdefault("is_superuser", False)
+        return self._create_user(email, password, **extra_fields)
+
+    def create_superuser(self, email, password, **extra_fields):
+        extra_fields.setdefault("is_staff", True)
+        extra_fields.setdefault("is_superuser", True)
+
+        if extra_fields.get("is_staff") is not True:
+            raise ValueError("Superuser must have is_staff=True.")
+        if extra_fields.get("is_superuser") is not True:
+            raise ValueError("Superuser must have is_superuser=True.")
+
+        return self._create_user(email, password, **extra_fields)
+
+
+class User(AbstractUser):
+    username = None
+    email = models.EmailField("email address", unique=True)
+    name = models.CharField(max_length=150)
+
+    USERNAME_FIELD = "email"
+    REQUIRED_FIELDS = ["name"]
+
+    objects = UserManager()
+
+    def __str__(self):
+        return self.email
+
+
+class Company(models.Model):
+    owner = models.OneToOneField(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name="company")
+    name = models.CharField(max_length=10, unique=True)
+    currency = models.CharField(max_length=3)
+    language = models.CharField(max_length=5, choices=[("en", "English"), ("ar", "Arabic")])
+    periods = models.PositiveSmallIntegerField(default=12)
+    current_period = models.PositiveSmallIntegerField(default=1)
+    thousand_separator = models.CharField(max_length=1, blank=True)
+    decimal_places = models.PositiveSmallIntegerField(default=2)
+    decimal_separator = models.CharField(max_length=1, default=".")
+    date_format = models.CharField(max_length=20, default="dd/mm/yyyy")
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        verbose_name = _("Company")
+        verbose_name_plural = _("Companies")
+
+    def __str__(self):
+        return self.name

--- a/backend/accounts/serializers.py
+++ b/backend/accounts/serializers.py
@@ -1,0 +1,115 @@
+from django.contrib.auth import authenticate
+from django.db import transaction
+from rest_framework import serializers
+from rest_framework.exceptions import AuthenticationFailed
+from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from .models import Company, User
+
+
+class CompanySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Company
+        exclude = ("owner", "id")
+
+
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ("id", "email", "name")
+
+
+class RegistrationSerializer(serializers.Serializer):
+    email = serializers.EmailField()
+    name = serializers.CharField(max_length=150)
+    password = serializers.CharField(min_length=8, write_only=True)
+    company_name = serializers.CharField(max_length=10)
+    currency = serializers.CharField(max_length=3)
+    language = serializers.ChoiceField(choices=("en", "ar"))
+    periods = serializers.IntegerField(min_value=1, max_value=24)
+    current_period = serializers.IntegerField(min_value=1)
+    thousand_separator = serializers.CharField(max_length=1, allow_blank=True)
+    decimal_places = serializers.IntegerField(min_value=0, max_value=4)
+    decimal_separator = serializers.ChoiceField(choices=(".", ","))
+    date_format = serializers.ChoiceField(choices=("dd/mm/yyyy", "mm/dd/yyyy", "yyyy/mm/dd"))
+
+    def validate_company_name(self, value: str):
+        if " " in value:
+            raise serializers.ValidationError("Use one word without spaces.")
+        if not value.isalnum():
+            raise serializers.ValidationError("Only letters and numbers are allowed.")
+        normalized = value.lower()
+        if Company.objects.filter(name=normalized).exists():
+            raise serializers.ValidationError("Company identifier already exists.")
+        return normalized
+
+    def validate_currency(self, value: str):
+        return value.upper()
+
+    def validate_thousand_separator(self, value: str):
+        allowed = {"", ",", ".", "none"}
+        if value not in allowed:
+            raise serializers.ValidationError("Invalid thousand separator")
+        return "" if value == "none" else value
+
+    def validate(self, attrs):
+        if attrs["current_period"] > attrs["periods"]:
+            raise serializers.ValidationError("Current period cannot exceed total periods.")
+        return attrs
+
+    @transaction.atomic
+    def create(self, validated_data):
+        password = validated_data.pop("password")
+        company_name = validated_data.pop("company_name")
+
+        user = User.objects.create_user(
+            email=validated_data["email"],
+            name=validated_data["name"],
+            password=password,
+        )
+
+        Company.objects.create(
+            owner=user,
+            name=company_name,
+            currency=validated_data["currency"],
+            language=validated_data["language"],
+            periods=validated_data["periods"],
+            current_period=validated_data["current_period"],
+            thousand_separator=validated_data["thousand_separator"],
+            decimal_places=validated_data["decimal_places"],
+            decimal_separator=validated_data["decimal_separator"],
+            date_format=validated_data["date_format"],
+        )
+        return user
+
+    def to_representation(self, instance):
+        refresh = RefreshToken.for_user(instance)
+        return {"access": str(refresh.access_token), "refresh": str(refresh)}
+
+
+class EmailTokenObtainPairSerializer(TokenObtainPairSerializer):
+    username_field = User.EMAIL_FIELD
+
+    def validate(self, attrs):
+        authenticate_kwargs = {
+            self.username_field: attrs.get("email"),
+            "password": attrs.get("password"),
+        }
+        user = authenticate(request=self.context.get("request"), **authenticate_kwargs)
+        if not user:
+            raise AuthenticationFailed("Invalid credentials")
+        refresh = RefreshToken.for_user(user)
+        return {"access": str(refresh.access_token), "refresh": str(refresh)}
+
+
+class ProfileSerializer(serializers.Serializer):
+    user = UserSerializer()
+    company = CompanySerializer()
+
+    @classmethod
+    def from_user(cls, user: User):
+        company = getattr(user, "company", None)
+        if not company:
+            raise serializers.ValidationError("User does not have an associated company")
+        return cls(instance={"user": UserSerializer(user).data, "company": CompanySerializer(company).data})

--- a/backend/accounts/urls.py
+++ b/backend/accounts/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path
+
+from .views import LoginView, LogoutView, ProfileView, RegisterView
+
+urlpatterns = [
+    path("auth/register/", RegisterView.as_view(), name="register"),
+    path("auth/login/", LoginView.as_view(), name="login"),
+    path("auth/logout/", LogoutView.as_view(), name="logout"),
+    path("profile/", ProfileView.as_view(), name="profile"),
+]

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -1,0 +1,56 @@
+from rest_framework import generics, permissions, status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from rest_framework_simplejwt.exceptions import TokenError
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from .serializers import (
+    EmailTokenObtainPairSerializer,
+    ProfileSerializer,
+    RegistrationSerializer,
+)
+
+
+class RegisterView(generics.CreateAPIView):
+    serializer_class = RegistrationSerializer
+    permission_classes = [permissions.AllowAny]
+
+    def create(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        headers = self.get_success_headers(serializer.data)
+        return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
+
+
+class LoginView(generics.GenericAPIView):
+    serializer_class = EmailTokenObtainPairSerializer
+    permission_classes = [permissions.AllowAny]
+
+    def post(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        return Response(serializer.validated_data, status=status.HTTP_200_OK)
+
+
+class LogoutView(APIView):
+    permission_classes = [permissions.AllowAny]
+
+    def post(self, request, *args, **kwargs):
+        refresh_token = request.data.get("refresh")
+        if not refresh_token:
+            return Response({"detail": "Refresh token required"}, status=status.HTTP_400_BAD_REQUEST)
+        try:
+            token = RefreshToken(refresh_token)
+            token.blacklist()
+        except TokenError:
+            return Response({"detail": "Invalid token"}, status=status.HTTP_400_BAD_REQUEST)
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class ProfileView(APIView):
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get(self, request, *args, **kwargs):
+        profile = ProfileSerializer.from_user(request.user)
+        return Response(profile.data)

--- a/backend/manage.py
+++ b/backend/manage.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+import os
+import sys
+
+
+def main():
+  os.environ.setdefault("DJANGO_SETTINGS_MODULE", "nxentra_backend.settings")
+  try:
+    from django.core.management import execute_from_command_line
+  except ImportError as exc:
+    raise ImportError("Couldn't import Django") from exc
+  execute_from_command_line(sys.argv)
+
+
+if __name__ == "__main__":
+  main()

--- a/backend/nxentra_backend/asgi.py
+++ b/backend/nxentra_backend/asgi.py
@@ -1,0 +1,6 @@
+import os
+from django.core.asgi import get_asgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "nxentra_backend.settings")
+
+application = get_asgi_application()

--- a/backend/nxentra_backend/settings.py
+++ b/backend/nxentra_backend/settings.py
@@ -1,0 +1,105 @@
+from pathlib import Path
+import os
+from datetime import timedelta
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY", "changeme")
+DEBUG = os.environ.get("DJANGO_DEBUG", "True") == "True"
+ALLOWED_HOSTS = os.environ.get("DJANGO_ALLOWED_HOSTS", "*").split(",")
+
+INSTALLED_APPS = [
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "corsheaders",
+    "rest_framework",
+    "rest_framework_simplejwt.token_blacklist",
+    "accounts",
+]
+
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+]
+
+ROOT_URLCONF = "nxentra_backend.urls"
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ],
+        },
+    }
+]
+
+WSGI_APPLICATION = "nxentra_backend.wsgi.application"
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": os.environ.get("POSTGRES_DB", "nxentra"),
+        "USER": os.environ.get("POSTGRES_USER", "nxentra"),
+        "PASSWORD": os.environ.get("POSTGRES_PASSWORD", "nxentra"),
+        "HOST": os.environ.get("POSTGRES_HOST", "localhost"),
+        "PORT": os.environ.get("POSTGRES_PORT", "5432"),
+    }
+}
+
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
+        "OPTIONS": {"min_length": 8},
+    },
+]
+
+LANGUAGE_CODE = "en-us"
+TIME_ZONE = "UTC"
+USE_I18N = True
+USE_TZ = True
+
+STATIC_URL = "static/"
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+AUTH_USER_MODEL = "accounts.User"
+
+REST_FRAMEWORK = {
+    "DEFAULT_AUTHENTICATION_CLASSES": (
+        "rest_framework_simplejwt.authentication.JWTAuthentication",
+    ),
+    "DEFAULT_PERMISSION_CLASSES": (
+        "rest_framework.permissions.IsAuthenticated",
+    )
+}
+
+SIMPLE_JWT = {
+    "ACCESS_TOKEN_LIFETIME": timedelta(minutes=30),
+    "REFRESH_TOKEN_LIFETIME": timedelta(days=30),
+    "ROTATE_REFRESH_TOKENS": True,
+    "BLACKLIST_AFTER_ROTATION": True,
+}
+
+CORS_ALLOWED_ORIGINS = os.environ.get("CORS_ALLOWED_ORIGINS", "http://localhost:3000").split(",")
+CORS_ALLOW_CREDENTIALS = True
+
+CSRF_TRUSTED_ORIGINS = os.environ.get("CSRF_TRUSTED_ORIGINS", "http://localhost:3000").split(",")

--- a/backend/nxentra_backend/urls.py
+++ b/backend/nxentra_backend/urls.py
@@ -1,0 +1,7 @@
+from django.contrib import admin
+from django.urls import include, path
+
+urlpatterns = [
+    path("admin/", admin.site.urls),
+    path("api/", include("accounts.urls")),
+]

--- a/backend/nxentra_backend/wsgi.py
+++ b/backend/nxentra_backend/wsgi.py
@@ -1,0 +1,6 @@
+import os
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "nxentra_backend.settings")
+
+application = get_wsgi_application()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,5 @@
+django>=4.2,<5.0
+djangorestframework>=3.14
+psycopg2-binary>=2.9
+django-cors-headers>=3.14
+djangorestframework-simplejwt>=5.3

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=http://localhost:8000/api

--- a/frontend/components/AuthLayout.tsx
+++ b/frontend/components/AuthLayout.tsx
@@ -1,0 +1,20 @@
+import Link from "next/link";
+import { PropsWithChildren } from "react";
+
+export function AuthLayout({ children }: PropsWithChildren) {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-900 via-slate-950 to-slate-900">
+      <div className="w-full max-w-3xl rounded-3xl border border-slate-800 bg-slate-900/70 p-10 shadow-xl shadow-slate-900/60 backdrop-blur">
+        <header className="mb-8 text-center">
+          <Link href="/" className="text-3xl font-semibold text-accent">
+            Nxentra ERP Access
+          </Link>
+          <p className="mt-2 text-sm text-slate-400">
+            Secure multi-tenant onboarding for your smart ERP workspace.
+          </p>
+        </header>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/FormField.tsx
+++ b/frontend/components/FormField.tsx
@@ -1,0 +1,78 @@
+import { clsx } from "clsx";
+import { HTMLInputTypeAttribute, ReactNode } from "react";
+
+interface BaseProps {
+  id: string;
+  label: string;
+  children?: ReactNode;
+  error?: string;
+}
+
+interface InputProps extends BaseProps {
+  type?: HTMLInputTypeAttribute;
+  value: string | number;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}
+
+export function InputField({
+  id,
+  label,
+  type = "text",
+  value,
+  onChange,
+  placeholder,
+  error
+}: InputProps) {
+  return (
+    <div className="space-y-2">
+      <label className="block text-sm font-medium text-slate-200" htmlFor={id}>
+        {label}
+      </label>
+      <input
+        id={id}
+        name={id}
+        type={type}
+        value={value}
+        placeholder={placeholder}
+        onChange={(event) => onChange(event.target.value)}
+        className={clsx(
+          "w-full rounded-xl border border-slate-800 bg-slate-900/60 px-4 py-3 text-slate-100 transition",
+          "placeholder:text-slate-500 focus:border-accent focus:outline-none focus:ring focus:ring-accent/20",
+          error && "border-red-500/70 focus:border-red-500/70 focus:ring-red-500/20"
+        )}
+      />
+      {error && <p className="text-sm text-red-400">{error}</p>}
+    </div>
+  );
+}
+
+interface SelectProps extends BaseProps {
+  value: string;
+  onChange: (value: string) => void;
+  children: ReactNode;
+}
+
+export function SelectField({ id, label, value, onChange, children, error }: SelectProps) {
+  return (
+    <div className="space-y-2">
+      <label className="block text-sm font-medium text-slate-200" htmlFor={id}>
+        {label}
+      </label>
+      <select
+        id={id}
+        name={id}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className={clsx(
+          "w-full rounded-xl border border-slate-800 bg-slate-900/60 px-4 py-3 text-slate-100 transition",
+          "focus:border-accent focus:outline-none focus:ring focus:ring-accent/20",
+          error && "border-red-500/70 focus:border-red-500/70 focus:ring-red-500/20"
+        )}
+      >
+        {children}
+      </select>
+      {error && <p className="text-sm text-red-400">{error}</p>}
+    </div>
+  );
+}

--- a/frontend/components/LoadingOverlay.tsx
+++ b/frontend/components/LoadingOverlay.tsx
@@ -1,0 +1,24 @@
+import { motion } from "framer-motion";
+
+interface LoadingOverlayProps {
+  message?: string;
+}
+
+export function LoadingOverlay({ message = "Setting up your workspace..." }: LoadingOverlayProps) {
+  return (
+    <div className="absolute inset-0 z-20 flex flex-col items-center justify-center gap-6 rounded-3xl bg-slate-950/90">
+      <motion.div
+        className="h-24 w-24 rounded-full border-4 border-slate-800 border-t-accent"
+        animate={{ rotate: 360 }}
+        transition={{ repeat: Infinity, ease: "linear", duration: 1 }}
+      />
+      <motion.p
+        className="text-lg font-medium text-slate-200"
+        animate={{ opacity: [0.3, 1, 0.3] }}
+        transition={{ repeat: Infinity, duration: 2 }}
+      >
+        {message}
+      </motion.p>
+    </div>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,0 +1,68 @@
+import axios from "axios";
+
+const api = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/api",
+  withCredentials: true
+});
+
+export interface AuthResponse {
+  access: string;
+  refresh: string;
+}
+
+export interface RegistrationPayload {
+  email: string;
+  name: string;
+  password: string;
+  company_name: string;
+  currency: string;
+  language: string;
+  periods: number;
+  current_period: number;
+  thousand_separator: string;
+  decimal_places: number;
+  decimal_separator: string;
+  date_format: string;
+}
+
+export async function register(payload: RegistrationPayload): Promise<AuthResponse> {
+  const response = await api.post<AuthResponse>('/auth/register/', payload);
+  return response.data;
+}
+
+export async function login(email: string, password: string): Promise<AuthResponse> {
+  const response = await api.post<AuthResponse>('/auth/login/', { email, password });
+  return response.data;
+}
+
+export async function logout(refresh: string) {
+  await api.post('/auth/logout/', { refresh });
+}
+
+export interface ProfileResponse {
+  user: {
+    id: number;
+    email: string;
+    name: string;
+  };
+  company: {
+    name: string;
+    currency: string;
+    language: string;
+    periods: number;
+    current_period: number;
+    thousand_separator: string;
+    decimal_places: number;
+    decimal_separator: string;
+    date_format: string;
+  };
+}
+
+export async function getProfile(accessToken: string): Promise<ProfileResponse> {
+  const response = await api.get<ProfileResponse>('/profile/', {
+    headers: {
+      Authorization: `Bearer ${accessToken}`
+    }
+  });
+  return response.data;
+}

--- a/frontend/lib/auth-storage.ts
+++ b/frontend/lib/auth-storage.ts
@@ -1,0 +1,24 @@
+const ACCESS_TOKEN_KEY = "nxentra_access";
+const REFRESH_TOKEN_KEY = "nxentra_refresh";
+
+export function storeTokens(access: string, refresh: string) {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(ACCESS_TOKEN_KEY, access);
+  localStorage.setItem(REFRESH_TOKEN_KEY, refresh);
+}
+
+export function clearTokens() {
+  if (typeof window === "undefined") return;
+  localStorage.removeItem(ACCESS_TOKEN_KEY);
+  localStorage.removeItem(REFRESH_TOKEN_KEY);
+}
+
+export function getAccessToken() {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem(ACCESS_TOKEN_KEY);
+}
+
+export function getRefreshToken() {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem(REFRESH_TOKEN_KEY);
+}

--- a/frontend/lib/constants.ts
+++ b/frontend/lib/constants.ts
@@ -1,0 +1,27 @@
+export const currencyOptions = [
+  "USD",
+  "EUR",
+  "GBP",
+  "AED",
+  "SAR",
+  "EGP",
+  "KWD",
+  "QAR",
+  "OMR"
+];
+
+export const languageOptions = [
+  { value: "en", label: "English" },
+  { value: "ar", label: "Arabic" }
+];
+
+export const thousandSeparators = [",", ".", "none"] as const;
+export const decimalSeparators = [".", ","] as const;
+export const decimalPlaces = ["0", "1", "2", "3", "4"] as const;
+export const dateFormats = ["dd/mm/yyyy", "mm/dd/yyyy", "yyyy/mm/dd"] as const;
+
+export const accountingPeriods = [
+  { value: "12", label: "12 (Monthly)" },
+  { value: "4", label: "4 (Quarterly)" },
+  { value: "1", label: "1 (Yearly)" }
+];

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    typedRoutes: true
+  }
+};
+
+module.exports = nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "nxentra-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "axios": "^1.6.7",
+    "clsx": "^2.0.0",
+    "framer-motion": "^10.16.4",
+    "next": "14.0.4",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.17",
+    "@types/react": "18.2.46",
+    "@types/react-dom": "18.2.18",
+    "autoprefixer": "10.4.16",
+    "postcss": "8.4.33",
+    "tailwindcss": "3.4.1",
+    "typescript": "5.3.3"
+  }
+}

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,0 +1,15 @@
+import "@/styles/globals.css";
+import type { AppProps } from "next/app";
+import Head from "next/head";
+
+export default function App({ Component, pageProps }: AppProps) {
+  return (
+    <>
+      <Head>
+        <title>Nxentra Access</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </Head>
+      <Component {...pageProps} />
+    </>
+  );
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link";
+
+export default function HomePage() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center bg-slate-950 px-6 py-20 text-center text-slate-100">
+      <div className="max-w-4xl space-y-8">
+        <h1 className="text-4xl font-bold sm:text-5xl">
+          Nxentra Smart ERP Access Platform
+        </h1>
+        <p className="text-lg text-slate-400">
+          Manage registration, login, and tenant onboarding for your ERP workspace.
+          Deploy the modern Next.js front-end on Vercel and serve the secure Django REST API from Digital Ocean.
+        </p>
+        <div className="flex flex-wrap items-center justify-center gap-4">
+          <Link
+            href="/register"
+            className="rounded-full bg-accent px-6 py-3 font-semibold text-slate-950 shadow-lg shadow-accent/30 transition hover:bg-sky-400"
+          >
+            Create Company Workspace
+          </Link>
+          <Link
+            href="/login"
+            className="rounded-full border border-slate-700 px-6 py-3 font-semibold text-slate-100 transition hover:border-accent"
+          >
+            Login to Existing Workspace
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/frontend/pages/login.tsx
+++ b/frontend/pages/login.tsx
@@ -1,0 +1,60 @@
+import Link from "next/link";
+import { FormEvent, useState } from "react";
+import { useRouter } from "next/router";
+import { AuthLayout } from "@/components/AuthLayout";
+import { InputField } from "@/components/FormField";
+import { login } from "@/lib/api";
+import { storeTokens } from "@/lib/auth-storage";
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setError(null);
+
+    try {
+      setIsSubmitting(true);
+      const response = await login(email, password);
+      storeTokens(response.access, response.refresh);
+      await router.push("/profile");
+    } catch (loginError) {
+      console.error(loginError);
+      setError("Invalid credentials. Please try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <AuthLayout>
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <div>
+          <h2 className="text-2xl font-semibold text-slate-100">Login to your workspace</h2>
+          <p className="mt-2 text-sm text-slate-400">
+            Enter the email and password you used during onboarding.
+          </p>
+        </div>
+        <InputField id="email" label="Email" type="email" value={email} onChange={setEmail} />
+        <InputField id="password" label="Password" type="password" value={password} onChange={setPassword} />
+
+        {error && <p className="text-sm text-red-400">{error}</p>}
+
+        <button
+          type="submit"
+          className="w-full rounded-full bg-accent px-8 py-3 text-center font-semibold text-slate-950 shadow-lg shadow-accent/30 transition hover:bg-sky-400"
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? "Authenticating..." : "Login"}
+        </button>
+        <p className="text-sm text-slate-400">
+          Need to onboard a workspace? <Link href="/register">Register</Link>
+        </p>
+      </form>
+    </AuthLayout>
+  );
+}

--- a/frontend/pages/profile.tsx
+++ b/frontend/pages/profile.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import { AuthLayout } from "@/components/AuthLayout";
+import { getProfile, ProfileResponse, logout } from "@/lib/api";
+import { clearTokens, getAccessToken, getRefreshToken } from "@/lib/auth-storage";
+
+export default function ProfilePage() {
+  const router = useRouter();
+  const [profile, setProfile] = useState<ProfileResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchProfile = async () => {
+      const accessToken = getAccessToken();
+      if (!accessToken) {
+        router.replace("/login");
+        return;
+      }
+
+      try {
+        const profileResponse = await getProfile(accessToken);
+        setProfile(profileResponse);
+      } catch (error) {
+        console.error(error);
+        router.replace("/login");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchProfile();
+  }, [router]);
+
+  const handleLogout = async () => {
+    const refresh = getRefreshToken();
+    if (refresh) {
+      try {
+        await logout(refresh);
+      } catch (error) {
+        console.error("Failed to revoke refresh token", error);
+      }
+    }
+    clearTokens();
+    router.replace("/login");
+  };
+
+  if (loading) {
+    return (
+      <AuthLayout>
+        <div className="space-y-3 text-center">
+          <p className="text-sm text-slate-400">Loading your workspace preferences...</p>
+        </div>
+      </AuthLayout>
+    );
+  }
+
+  if (!profile) {
+    return null;
+  }
+
+  const { user, company } = profile;
+
+  return (
+    <AuthLayout>
+      <div className="space-y-8">
+        <header>
+          <h2 className="text-3xl font-semibold text-slate-100">Welcome back, {user.name}</h2>
+          <p className="mt-2 text-sm text-slate-400">Here are the settings that power your Nxentra ERP tenant.</p>
+        </header>
+
+        <section className="rounded-3xl border border-slate-800 bg-slate-900/50 p-6">
+          <h3 className="text-xl font-semibold text-slate-200">Company workspace</h3>
+          <dl className="mt-4 grid grid-cols-1 gap-4 text-sm text-slate-300 md:grid-cols-2">
+            <div>
+              <dt className="text-slate-500">Database name</dt>
+              <dd className="text-lg font-medium text-slate-100">{company.name}</dd>
+            </div>
+            <div>
+              <dt className="text-slate-500">Currency</dt>
+              <dd className="text-lg font-medium text-slate-100">{company.currency}</dd>
+            </div>
+            <div>
+              <dt className="text-slate-500">Language</dt>
+              <dd className="text-lg font-medium text-slate-100">{company.language === "ar" ? "Arabic" : "English"}</dd>
+            </div>
+            <div>
+              <dt className="text-slate-500">Accounting periods</dt>
+              <dd className="text-lg font-medium text-slate-100">{company.periods}</dd>
+            </div>
+            <div>
+              <dt className="text-slate-500">Current period</dt>
+              <dd className="text-lg font-medium text-slate-100">{company.current_period}</dd>
+            </div>
+            <div>
+              <dt className="text-slate-500">Thousands separator</dt>
+              <dd className="text-lg font-medium text-slate-100">{company.thousand_separator || "None"}</dd>
+            </div>
+            <div>
+              <dt className="text-slate-500">Decimal places</dt>
+              <dd className="text-lg font-medium text-slate-100">{company.decimal_places}</dd>
+            </div>
+            <div>
+              <dt className="text-slate-500">Decimal separator</dt>
+              <dd className="text-lg font-medium text-slate-100">{company.decimal_separator}</dd>
+            </div>
+            <div>
+              <dt className="text-slate-500">Date format</dt>
+              <dd className="text-lg font-medium text-slate-100">{company.date_format}</dd>
+            </div>
+          </dl>
+        </section>
+
+        <button
+          onClick={handleLogout}
+          className="w-full rounded-full border border-slate-700 px-8 py-3 font-semibold text-slate-100 transition hover:border-red-500 hover:text-red-400"
+        >
+          Logout
+        </button>
+      </div>
+    </AuthLayout>
+  );
+}

--- a/frontend/pages/register.tsx
+++ b/frontend/pages/register.tsx
@@ -1,0 +1,255 @@
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { FormEvent, useState } from "react";
+import { AuthLayout } from "@/components/AuthLayout";
+import { InputField, SelectField } from "@/components/FormField";
+import { LoadingOverlay } from "@/components/LoadingOverlay";
+import {
+  accountingPeriods,
+  currencyOptions,
+  dateFormats,
+  decimalPlaces,
+  decimalSeparators,
+  languageOptions,
+  thousandSeparators
+} from "@/lib/constants";
+import { register } from "@/lib/api";
+import { storeTokens } from "@/lib/auth-storage";
+
+const initialState = {
+  email: "",
+  name: "",
+  password: "",
+  company_name: "",
+  currency: "USD",
+  language: "en",
+  periods: "12",
+  current_period: "1",
+  thousand_separator: ",",
+  decimal_places: "2",
+  decimal_separator: ".",
+  date_format: "dd/mm/yyyy"
+};
+
+type Errors = Partial<Record<keyof typeof initialState, string>>;
+
+export default function RegisterPage() {
+  const router = useRouter();
+  const [form, setForm] = useState(initialState);
+  const [errors, setErrors] = useState<Errors>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [showOverlay, setShowOverlay] = useState(false);
+
+  const handleChange = (field: keyof typeof form) => (value: string) => {
+    setForm((previous) => {
+      const nextForm = { ...previous, [field]: value };
+      if (field === "periods") {
+        const total = Number(value);
+        if (Number(nextForm.current_period) > total) {
+          nextForm.current_period = String(total);
+        }
+      }
+      return nextForm;
+    });
+  };
+
+  const validate = () => {
+    const validationErrors: Errors = {};
+
+    if (!form.email) validationErrors.email = "Email is required";
+    if (!form.name) validationErrors.name = "Name is required";
+    if (!form.password || form.password.length < 8)
+      validationErrors.password = "Password must be at least 8 characters";
+    if (!form.company_name)
+      validationErrors.company_name = "Company database name is required";
+    if (form.company_name && form.company_name.includes(" "))
+      validationErrors.company_name = "Use a single word with no spaces";
+    if (form.company_name.length > 10)
+      validationErrors.company_name = "Maximum 10 characters";
+
+    const currentPeriodNumber = Number(form.current_period);
+    const totalPeriodsNumber = Number(form.periods);
+    if (currentPeriodNumber > totalPeriodsNumber) {
+      validationErrors.current_period = "Cannot exceed total periods";
+    }
+
+    setErrors(validationErrors);
+    return Object.keys(validationErrors).length === 0;
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!validate()) return;
+
+    try {
+      setIsSubmitting(true);
+      const response = await register({
+        email: form.email,
+        name: form.name,
+        password: form.password,
+        company_name: form.company_name,
+        currency: form.currency,
+        language: form.language,
+        periods: Number(form.periods),
+        current_period: Number(form.current_period),
+        thousand_separator: form.thousand_separator === "none" ? "" : form.thousand_separator,
+        decimal_places: Number(form.decimal_places),
+        decimal_separator: form.decimal_separator,
+        date_format: form.date_format
+      });
+
+      storeTokens(response.access, response.refresh);
+      setShowOverlay(true);
+      setTimeout(() => {
+        router.push("/profile");
+      }, 1800);
+    } catch (error) {
+      console.error(error);
+      setErrors({ email: "Registration failed. Please try again." });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <AuthLayout>
+      <div className="relative">
+        {showOverlay && <LoadingOverlay />}
+        <form onSubmit={handleSubmit} className="grid grid-cols-1 gap-6 md:grid-cols-2">
+          <div className="md:col-span-2">
+            <h2 className="text-2xl font-semibold text-slate-100">Create your company workspace</h2>
+            <p className="mt-2 text-sm text-slate-400">
+              Enter basic account credentials and configure the accounting experience for your ERP tenant.
+            </p>
+          </div>
+          <InputField id="email" label="Email" type="email" value={form.email} onChange={handleChange("email")} error={errors.email} />
+          <InputField id="name" label="Full name" value={form.name} onChange={handleChange("name")} error={errors.name} />
+          <InputField
+            id="password"
+            label="Password"
+            type="password"
+            value={form.password}
+            onChange={handleChange("password")}
+            error={errors.password}
+          />
+          <InputField
+            id="company_name"
+            label="Company database name"
+            value={form.company_name}
+            onChange={handleChange("company_name")}
+            placeholder="e.g. nxentra"
+            error={errors.company_name}
+          />
+
+          <SelectField id="currency" label="Functional currency" value={form.currency} onChange={handleChange("currency")}>
+            {currencyOptions.map((currency) => (
+              <option key={currency} value={currency}>
+                {currency}
+              </option>
+            ))}
+          </SelectField>
+
+          <SelectField id="language" label="Interface language" value={form.language} onChange={handleChange("language")}>
+            {languageOptions.map((language) => (
+              <option key={language.value} value={language.value}>
+                {language.label}
+              </option>
+            ))}
+          </SelectField>
+
+          <SelectField
+            id="periods"
+            label="Number of accounting periods"
+            value={form.periods}
+            onChange={handleChange("periods")}
+          >
+            {accountingPeriods.map((period) => (
+              <option key={period.value} value={period.value}>
+                {period.label}
+              </option>
+            ))}
+          </SelectField>
+
+          <SelectField
+            id="current_period"
+            label="Current accounting period"
+            value={form.current_period}
+            onChange={handleChange("current_period")}
+            error={errors.current_period}
+          >
+            {Array.from({ length: Math.max(1, Number(form.periods) || 1) }, (_, index) => index + 1).map((period) => (
+              <option key={period} value={period}>
+                {period}
+              </option>
+            ))}
+          </SelectField>
+
+          <SelectField
+            id="thousand_separator"
+            label="Thousands separator"
+            value={form.thousand_separator}
+            onChange={handleChange("thousand_separator")}
+          >
+            {thousandSeparators.map((separator) => (
+              <option key={separator} value={separator}>
+                {separator === "none" ? "None" : separator}
+              </option>
+            ))}
+          </SelectField>
+
+          <SelectField
+            id="decimal_places"
+            label="Number of decimal places"
+            value={form.decimal_places}
+            onChange={handleChange("decimal_places")}
+          >
+            {decimalPlaces.map((places) => (
+              <option key={places} value={places}>
+                {places}
+              </option>
+            ))}
+          </SelectField>
+
+          <SelectField
+            id="decimal_separator"
+            label="Decimal separator"
+            value={form.decimal_separator}
+            onChange={handleChange("decimal_separator")}
+          >
+            {decimalSeparators.map((separator) => (
+              <option key={separator} value={separator}>
+                {separator}
+              </option>
+            ))}
+          </SelectField>
+
+          <SelectField
+            id="date_format"
+            label="Preferred date format"
+            value={form.date_format}
+            onChange={handleChange("date_format")}
+          >
+            {dateFormats.map((format) => (
+              <option key={format} value={format}>
+                {format}
+              </option>
+            ))}
+          </SelectField>
+
+          <div className="md:col-span-2 flex flex-col gap-3">
+            <button
+              type="submit"
+              className="rounded-full bg-accent px-8 py-3 text-center font-semibold text-slate-950 shadow-lg shadow-accent/30 transition hover:bg-sky-400"
+              disabled={isSubmitting}
+            >
+              {isSubmitting ? "Submitting..." : "Launch Workspace"}
+            </button>
+            <p className="text-sm text-slate-400">
+              Already onboarded? <Link href="/login">Login</Link>
+            </p>
+          </div>
+        </form>
+      </div>
+    </AuthLayout>
+  );
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1,0 +1,15 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-slate-950 text-slate-100 min-h-screen;
+}
+
+a {
+  @apply text-accent;
+}
+
+button:disabled {
+  @apply opacity-60 cursor-not-allowed;
+}

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,0 +1,16 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: ["./pages/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}", "./app/**/*.{ts,tsx}"],
+  theme: {
+    extend: {
+      colors: {
+        primary: "#1e293b",
+        accent: "#0ea5e9"
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/components/*": ["components/*"],
+      "@/lib/*": ["lib/*"],
+      "@/styles/*": ["styles/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.cjs", "**/*.mjs"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold a Next.js 14 frontend with Tailwind styling for register, login, and profile pages tied to ERP onboarding metadata
- build a Django REST API with JWT authentication, custom user model, and company configuration persistence in PostgreSQL
- document local setup steps and provide environment templates for coordinating Vercel frontend and DigitalOcean backend deployments

## Testing
- npm install *(fails: registry access returns HTTP 403 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4afb2654c8320ba5adbc6cf86e54e