### PR TITLE
chore(ci): pin type-check toolchain to restore the mypy-spine gate

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -43,7 +43,15 @@ pytest-django>=4.7.0
 sentry-sdk[django,celery]>=2.0.0
 
 # Code quality
+# Type-check toolchain PINNED to a known-good, spine-passing set (2026-06-20).
+# Unpinned `>=` let CI drift to django-stubs 6.0.5 (pulled in by drf-stubs 3.17.0),
+# whose stricter manager-generics broke the A102 mypy-spine gate on
+# accounting/models.py — a silent CI failure for 8+ days. The four below are
+# mutually compatible: django-stubs 6.0.1 requires mypy>=1.13,<1.20 (1.19.1 fits)
+# and django-stubs-ext>=6.0.1; drf-stubs 3.16.8 requires django-stubs>=5.2.8.
+# Bump deliberately (run scripts/check-types.py after), not via silent drift.
 ruff>=0.9.0
-mypy>=1.13.0
-django-stubs>=5.1.0
-djangorestframework-stubs>=3.15.0
+mypy==1.19.1
+django-stubs==6.0.1
+django-stubs-ext==6.0.1
+djangorestframework-stubs==3.16.8


### PR DESCRIPTION
## Problem
`main`'s CI **Lint & Type Check** job has been failing for 8+ days. Two stacked causes:

1. A pre-existing `RUF043` ruff error in `tests/test_a85_settlement_period_override.py` (fixed in #2) was masking everything after it.
2. Once that cleared, the job advanced to the **`mypy strict on canonical spine (blocking)`** step (A102) and surfaced **8 errors in `accounting/models.py`** — the custom `ProjectionWriteQuerySet` generics (`self.model.DoesNotExist`, `obj.save(_projection_write=...)`, `_Model`/`_Row`).

These are **not** real defects — they're django-stubs **6.0.5** being stricter about a legitimate runtime pattern. CI was pulling 6.0.5 only because of unpinned `>=` drift: `djangorestframework-stubs>=3.15.0` → resolved to 3.17.0 → dragged in `django-stubs` 6.0.5. Local dev (django-stubs 6.0.1) passes cleanly, so the breakage was invisible to developers.

**Impact:** the spine gate — the financial-critical typing guard from the Finance Event-First Policy — was a silent no-op. No spine type regression could be caught.

## Fix
Pin the type-check toolchain to the known-good, spine-passing set:

```
mypy==1.19.1
django-stubs==6.0.1
django-stubs-ext==6.0.1
djangorestframework-stubs==3.16.8
```

Mutually compatible: django-stubs 6.0.1 needs `mypy>=1.13,<1.20` (1.19.1 fits) + `django-stubs-ext>=6.0.1`; drf-stubs 3.16.8 needs `django-stubs>=5.2.8`. `django-stubs-ext` is **not** imported at runtime, so this is dev/CI-only — **zero runtime impact**.

## Verification
- `python scripts/check-types.py` → `Success: no issues found in 17 source files`
- `ruff check` → `All checks passed!`
- CI on this PR is the authoritative check — the Lint & Type Check job should now go green for the first time in over a week.

## Out of scope
`ruff` left ranged (`>=0.9.0`) — it's currently green and its pre-commit `rev` is tracked separately. Pin it as a follow-up if ruff drift recurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)